### PR TITLE
Updated Machine Specifications reference to 0.6.2.

### DIFF
--- a/Machine.Specifications.Mvc.nuspec
+++ b/Machine.Specifications.Mvc.nuspec
@@ -17,7 +17,7 @@ v1.0.2.0 - Added support for Partial View (ShouldBeAPartialView)
     <releaseNotes>Refactored "And" objects to a single generic object. Some return types in ActionResultExtensions (i.e. ViewResultAnd became ActionResultAnd&lt;ViewResult&gt;), so it could break someone's code if they wrote extension methods based on those return types.</releaseNotes>
     <projectUrl>https://github.com/joefeser/Machine.Specifications.Mvc</projectUrl>
     <dependencies>
-      <dependency id="Machine.Specifications" version="0.5.10" />
+      <dependency id="Machine.Specifications" version="0.6.2" />
     </dependencies>
     <iconUrl>http://github.com/machine/machine.specifications/raw/master/Misc/Machine.Specifications-32x32.png</iconUrl>
     <tags>MSpec test unit testing context specification bdd tdd</tags>

--- a/Source/Machine.Specifications.Mvc.Example/Machine.Specifications.Mvc.Example.csproj
+++ b/Source/Machine.Specifications.Mvc.Example/Machine.Specifications.Mvc.Example.csproj
@@ -53,16 +53,19 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Machine.Specifications, Version=0.5.10.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Machine.Specifications, Version=0.6.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Machine.Specifications.0.5.10\lib\net40\Machine.Specifications.dll</HintPath>
+      <HintPath>..\..\packages\Machine.Specifications.0.6.2\lib\net40\Machine.Specifications.dll</HintPath>
     </Reference>
-    <Reference Include="Machine.Specifications.Clr4, Version=0.5.10.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Machine.Specifications.Clr4, Version=0.6.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Machine.Specifications.0.5.10\lib\net40\Machine.Specifications.Clr4.dll</HintPath>
+      <HintPath>..\..\packages\Machine.Specifications.0.6.2\lib\net40\Machine.Specifications.Clr4.dll</HintPath>
+    </Reference>
+    <Reference Include="Machine.Specifications.Should">
+      <HintPath>..\..\packages\Machine.Specifications.0.6.2\lib\net40\Machine.Specifications.Should.dll</HintPath>
     </Reference>
     <Reference Include="Machine.Specifications.TDNetRunner">
-      <HintPath>..\..\packages\Machine.Specifications.0.5.10\lib\net40\Machine.Specifications.TDNetRunner.dll</HintPath>
+      <HintPath>..\..\packages\Machine.Specifications.0.6.2\lib\net40\Machine.Specifications.TDNetRunner.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/Source/Machine.Specifications.Mvc.Example/packages.config
+++ b/Source/Machine.Specifications.Mvc.Example/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Machine.Specifications" version="0.5.10" targetFramework="net40" />
+  <package id="Machine.Specifications" version="0.6.2" targetFramework="net40" />
 </packages>

--- a/Source/Machine.Specifications.Mvc.Specs/Machine.Specifications.Mvc.Specs.csproj
+++ b/Source/Machine.Specifications.Mvc.Specs/Machine.Specifications.Mvc.Specs.csproj
@@ -53,16 +53,19 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Machine.Specifications, Version=0.5.10.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Machine.Specifications, Version=0.6.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Machine.Specifications.0.5.10\lib\net40\Machine.Specifications.dll</HintPath>
+      <HintPath>..\..\packages\Machine.Specifications.0.6.2\lib\net40\Machine.Specifications.dll</HintPath>
     </Reference>
-    <Reference Include="Machine.Specifications.Clr4, Version=0.5.10.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Machine.Specifications.Clr4, Version=0.6.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Machine.Specifications.0.5.10\lib\net40\Machine.Specifications.Clr4.dll</HintPath>
+      <HintPath>..\..\packages\Machine.Specifications.0.6.2\lib\net40\Machine.Specifications.Clr4.dll</HintPath>
+    </Reference>
+    <Reference Include="Machine.Specifications.Should">
+      <HintPath>..\..\packages\Machine.Specifications.0.6.2\lib\net40\Machine.Specifications.Should.dll</HintPath>
     </Reference>
     <Reference Include="Machine.Specifications.TDNetRunner">
-      <HintPath>..\..\packages\Machine.Specifications.0.5.10\lib\net40\Machine.Specifications.TDNetRunner.dll</HintPath>
+      <HintPath>..\..\packages\Machine.Specifications.0.6.2\lib\net40\Machine.Specifications.TDNetRunner.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/Source/Machine.Specifications.Mvc.Specs/packages.config
+++ b/Source/Machine.Specifications.Mvc.Specs/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Machine.Specifications" version="0.5.10" targetFramework="net40" />
+  <package id="Machine.Specifications" version="0.6.2" targetFramework="net40" />
 </packages>

--- a/Source/Machine.Specifications.Mvc/Machine.Specifications.Mvc.csproj
+++ b/Source/Machine.Specifications.Mvc/Machine.Specifications.Mvc.csproj
@@ -53,16 +53,19 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Machine.Specifications, Version=0.5.10.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Machine.Specifications, Version=0.6.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Machine.Specifications.0.5.10\lib\net40\Machine.Specifications.dll</HintPath>
+      <HintPath>..\..\packages\Machine.Specifications.0.6.2\lib\net40\Machine.Specifications.dll</HintPath>
     </Reference>
-    <Reference Include="Machine.Specifications.Clr4, Version=0.5.10.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Machine.Specifications.Clr4, Version=0.6.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Machine.Specifications.0.5.10\lib\net40\Machine.Specifications.Clr4.dll</HintPath>
+      <HintPath>..\..\packages\Machine.Specifications.0.6.2\lib\net40\Machine.Specifications.Clr4.dll</HintPath>
+    </Reference>
+    <Reference Include="Machine.Specifications.Should">
+      <HintPath>..\..\packages\Machine.Specifications.0.6.2\lib\net40\Machine.Specifications.Should.dll</HintPath>
     </Reference>
     <Reference Include="Machine.Specifications.TDNetRunner">
-      <HintPath>..\..\packages\Machine.Specifications.0.5.10\lib\net40\Machine.Specifications.TDNetRunner.dll</HintPath>
+      <HintPath>..\..\packages\Machine.Specifications.0.6.2\lib\net40\Machine.Specifications.TDNetRunner.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core">

--- a/Source/Machine.Specifications.Mvc/packages.config
+++ b/Source/Machine.Specifications.Mvc/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Machine.Specifications" version="0.5.10" targetFramework="net40" />
+  <package id="Machine.Specifications" version="0.6.2" targetFramework="net40" />
 </packages>

--- a/mspec.bat
+++ b/mspec.bat
@@ -1,2 +1,2 @@
 @echo off
-"C:\work\github\Machine.Specifications.Mvc\packages\Machine.Specifications.0.5.10\tools\mspec-clr4.exe" %*
+"C:\work\github\Machine.Specifications.Mvc\packages\Machine.Specifications.0.6.2\tools\mspec-clr4.exe" %*


### PR DESCRIPTION
In the current Machine Specifications versions, the Should extension methods are in a separate assembly. Therefore, the old version of Machine.Specifications.Mvc no longer works and a new release (and NuGet package) should be created.
