### PR TITLE
Mspec 0.9.x update

### DIFF
--- a/Source/Machine.Specifications.Mvc.Example/Machine.Specifications.Mvc.Example.csproj
+++ b/Source/Machine.Specifications.Mvc.Example/Machine.Specifications.Mvc.Example.csproj
@@ -55,16 +55,17 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Machine.Specifications, Version=0.6.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Machine.Specifications.0.6.2\lib\net45\Machine.Specifications.dll</HintPath>
+    <Reference Include="Machine.Specifications, Version=0.9.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Machine.Specifications.0.9.3\lib\net45\Machine.Specifications.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Machine.Specifications.Clr4, Version=0.6.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Machine.Specifications.0.6.2\lib\net45\Machine.Specifications.Clr4.dll</HintPath>
+    <Reference Include="Machine.Specifications.Clr4, Version=0.9.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Machine.Specifications.0.9.3\lib\net45\Machine.Specifications.Clr4.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Machine.Specifications.Should">
-      <HintPath>..\..\packages\Machine.Specifications.0.6.2\lib\net45\Machine.Specifications.Should.dll</HintPath>
+    <Reference Include="Machine.Specifications.Should, Version=0.9.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Machine.Specifications.Should.0.9.0\lib\net45\Machine.Specifications.Should.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Machine.Specifications.TDNetRunner">
       <HintPath>..\..\packages\Machine.Specifications.0.6.2\lib\net40\Machine.Specifications.TDNetRunner.dll</HintPath>

--- a/Source/Machine.Specifications.Mvc.Example/packages.config
+++ b/Source/Machine.Specifications.Mvc.Example/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Machine.Specifications" version="0.6.2" targetFramework="net45" />
+  <package id="Machine.Specifications" version="0.9.3" targetFramework="net45" />
+  <package id="Machine.Specifications.Should" version="0.9.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.0.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.0.0" targetFramework="net45" />
 </packages>

--- a/Source/Machine.Specifications.Mvc.Specs/ActionResultExtensionsSpecs.cs
+++ b/Source/Machine.Specifications.Mvc.Specs/ActionResultExtensionsSpecs.cs
@@ -22,7 +22,7 @@ namespace Machine.Specifications.Mvc.Specs
 
         It should_not_throw_an_exception = () => exception.ShouldBeNull();
 
-        It should_allow_the_chaining_of_action_result_assertions = () => result.ShouldBeOfType<ActionResultAnd<TestActionResult>>();
+        It should_allow_the_chaining_of_action_result_assertions = () => result.ShouldBeAssignableTo<ActionResultAnd<TestActionResult>>();
     }
 
     [Subject(typeof(ActionResultExtensions))]
@@ -32,7 +32,7 @@ namespace Machine.Specifications.Mvc.Specs
 
         Because of = () => exception = Catch.Exception(() => new ViewResult().ShouldBeA<TestActionResult>());
 
-        It should_throw_an_exception = () => exception.ShouldBeOfType<SpecificationException>();
+        It should_throw_an_exception = () => exception.ShouldBeAssignableTo<SpecificationException>();
     }
 
     [Subject(typeof(ActionResultExtensions))]
@@ -45,7 +45,7 @@ namespace Machine.Specifications.Mvc.Specs
 
         It should_not_throw_an_exception = () => exception.ShouldBeNull();
 
-        It should_allow_the_chaining_of_view_result_assertions = () => result.ShouldBeOfType<ActionResultAnd<ViewResult>>();
+        It should_allow_the_chaining_of_view_result_assertions = () => result.ShouldBeAssignableTo<ActionResultAnd<ViewResult>>();
     }
 
     [Subject(typeof(ActionResultExtensions))]
@@ -55,7 +55,7 @@ namespace Machine.Specifications.Mvc.Specs
 
         Because of = () => exception = Catch.Exception(()=> new RedirectToRouteResult("", null).ShouldBeAView());
 
-        It should_throw_an_exception = () => exception.ShouldBeOfType<SpecificationException>();
+        It should_throw_an_exception = () => exception.ShouldBeAssignableTo<SpecificationException>();
     }
 
     [Subject(typeof(ActionResultExtensions))]
@@ -75,7 +75,7 @@ namespace Machine.Specifications.Mvc.Specs
 
         Because of = () => exception = Catch.Exception(()=> new RedirectToRouteResult("", null).ShouldBeAPartialView());
 
-        It should_throw_an_exception = () => exception.ShouldBeOfType<SpecificationException>();
+        It should_throw_an_exception = () => exception.ShouldBeAssignableTo<SpecificationException>();
     }
 
     [Subject(typeof(ActionResultExtensions))]
@@ -95,7 +95,7 @@ namespace Machine.Specifications.Mvc.Specs
 
         It should_throw_not_throw_an_exception = () => exception.ShouldBeNull();
 
-        It should_return_the_model_as_the_specified_type = () => result.ShouldBeOfType<string>();
+        It should_return_the_model_as_the_specified_type = () => result.ShouldBeAssignableTo<string>();
 
         It should_return_the_correct_model = () => result.ShouldEqual(model);
     }
@@ -113,7 +113,7 @@ namespace Machine.Specifications.Mvc.Specs
 
         Because of = () => exception = Catch.Exception(() => redirectResult.Model<string>());
 
-        It should_throw_an_exception = () => exception.ShouldBeOfType<SpecificationException>();
+        It should_throw_an_exception = () => exception.ShouldBeAssignableTo<SpecificationException>();
     }
 
     [Subject(typeof(ActionResultExtensions))]
@@ -130,7 +130,7 @@ namespace Machine.Specifications.Mvc.Specs
 
         Because of = () => exception = Catch.Exception(() => viewResult.Model<string>());
 
-        It should_throw_an_exception = () => exception.ShouldBeOfType<SpecificationException>();
+        It should_throw_an_exception = () => exception.ShouldBeAssignableTo<SpecificationException>();
     }
 
     [Subject(typeof(ActionResultExtensions))]
@@ -143,7 +143,7 @@ namespace Machine.Specifications.Mvc.Specs
 
         It should_not_throw_an_exception = () => exception.ShouldBeNull();
 
-        It should_allow_the_chaining_of_redirect_to_route_result_assertions = () => result.ShouldBeOfType<ActionResultAnd<RedirectToRouteResult>>();
+        It should_allow_the_chaining_of_redirect_to_route_result_assertions = () => result.ShouldBeAssignableTo<ActionResultAnd<RedirectToRouteResult>>();
     }
 
     [Subject(typeof(ActionResultExtensions))]
@@ -153,7 +153,7 @@ namespace Machine.Specifications.Mvc.Specs
 
         Because of = () => exception = Catch.Exception(() => new ViewResult().ShouldBeARedirectToRoute());
 
-        It should_throw_an_exception = () => exception.ShouldBeOfType<SpecificationException>();
+        It should_throw_an_exception = () => exception.ShouldBeAssignableTo<SpecificationException>();
     }
 
     [Subject(typeof(ActionResultExtensions))]
@@ -166,7 +166,7 @@ namespace Machine.Specifications.Mvc.Specs
 
         It should_not_throw_an_exception = () => exception.ShouldBeNull();
 
-        It should_allow_the_chaining_of_redirect_result_assertions = () => result.ShouldBeOfType<ActionResultAnd<RedirectResult>>();
+        It should_allow_the_chaining_of_redirect_result_assertions = () => result.ShouldBeAssignableTo<ActionResultAnd<RedirectResult>>();
     }
 
     [Subject(typeof(ActionResultExtensions))]
@@ -176,7 +176,7 @@ namespace Machine.Specifications.Mvc.Specs
 
         Because of = () => exception = Catch.Exception(() => new ViewResult().ShouldBeARedirect());
 
-        It should_throw_an_exception = () => exception.ShouldBeOfType<SpecificationException>();
+        It should_throw_an_exception = () => exception.ShouldBeAssignableTo<SpecificationException>();
     }
 
     [Subject(typeof(ActionResultExtensions), "Given an action redirects to another action on the same controller")]
@@ -224,7 +224,7 @@ namespace Machine.Specifications.Mvc.Specs
 
         Because of = () => exception = Catch.Exception(() => redirectToRouteResult.ShouldRedirectToAction<HomeController>(x => x.Index()));
 
-        It should_throw_an_exception = () => exception.ShouldBeOfType<SpecificationException>();
+        It should_throw_an_exception = () => exception.ShouldBeAssignableTo<SpecificationException>();
     }
 
     [Subject(typeof(ActionResultExtensions))]
@@ -240,7 +240,7 @@ namespace Machine.Specifications.Mvc.Specs
 
         Because of = () => exception = Catch.Exception(() => redirectToRouteResult.ShouldRedirectToAction<HomeController>(x => x.Index()));
 
-        It should_throw_an_exception = () => exception.ShouldBeOfType<SpecificationException>();
+        It should_throw_an_exception = () => exception.ShouldBeAssignableTo<SpecificationException>();
     }
 
     [Subject(typeof(ActionResultExtensions))]
@@ -250,7 +250,7 @@ namespace Machine.Specifications.Mvc.Specs
 
         Because of = () => exception = Catch.Exception(() => new ViewResult().ShouldRedirectToAction<HomeController>(x => x.Index()));
 
-        It should_throw_an_exception = () => exception.ShouldBeOfType<SpecificationException>();
+        It should_throw_an_exception = () => exception.ShouldBeAssignableTo<SpecificationException>();
     }
 
 

--- a/Source/Machine.Specifications.Mvc.Specs/ControllerExtensionsSpecs.cs
+++ b/Source/Machine.Specifications.Mvc.Specs/ControllerExtensionsSpecs.cs
@@ -25,7 +25,7 @@ namespace Machine.Specifications.Mvc.Specs
 
         Because of = () => exception = Catch.Exception(() => new HomeControllerNonStandard().RoutingName());
 
-        It should_throw_an_exception = () => exception.ShouldBeOfType<SpecificationException>();
+        It should_throw_an_exception = () => exception.ShouldBeAssignableTo<SpecificationException>();
     }
 
     [Subject(typeof(ControllerExtensions))]
@@ -35,7 +35,7 @@ namespace Machine.Specifications.Mvc.Specs
 
         Because of = () => exception = Catch.Exception(() => new Controller().RoutingName());
 
-        It should_throw_an_exception = () => exception.ShouldBeOfType<SpecificationException>();
+        It should_throw_an_exception = () => exception.ShouldBeAssignableTo<SpecificationException>();
     }
 
     internal class HomeControllerNonStandard : Controller

--- a/Source/Machine.Specifications.Mvc.Specs/ExpressionActionExtensionsSpecs.cs
+++ b/Source/Machine.Specifications.Mvc.Specs/ExpressionActionExtensionsSpecs.cs
@@ -38,6 +38,6 @@ namespace Machine.Specifications.Mvc.Specs
 
         Because of = () => exception = Catch.Exception(() => action.GetMethodBodyName());
 
-        It should_throw_an_exception = () => exception.ShouldBeOfType<SpecificationException>();
+        It should_throw_an_exception = () => exception.ShouldBeAssignableTo<SpecificationException>();
     }
 }   

--- a/Source/Machine.Specifications.Mvc.Specs/Machine.Specifications.Mvc.Specs.csproj
+++ b/Source/Machine.Specifications.Mvc.Specs/Machine.Specifications.Mvc.Specs.csproj
@@ -55,16 +55,17 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Machine.Specifications, Version=0.6.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Machine.Specifications.0.6.2\lib\net45\Machine.Specifications.dll</HintPath>
+    <Reference Include="Machine.Specifications, Version=0.9.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Machine.Specifications.0.9.3\lib\net45\Machine.Specifications.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Machine.Specifications.Clr4, Version=0.6.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Machine.Specifications.0.6.2\lib\net45\Machine.Specifications.Clr4.dll</HintPath>
+    <Reference Include="Machine.Specifications.Clr4, Version=0.9.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Machine.Specifications.0.9.3\lib\net45\Machine.Specifications.Clr4.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Machine.Specifications.Should">
-      <HintPath>..\..\packages\Machine.Specifications.0.6.2\lib\net45\Machine.Specifications.Should.dll</HintPath>
+    <Reference Include="Machine.Specifications.Should, Version=0.9.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Machine.Specifications.Should.0.9.0\lib\net45\Machine.Specifications.Should.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Machine.Specifications.TDNetRunner">
       <HintPath>..\..\packages\Machine.Specifications.0.6.2\lib\net40\Machine.Specifications.TDNetRunner.dll</HintPath>

--- a/Source/Machine.Specifications.Mvc.Specs/ViewResultBaseExtensionsSpecs.cs
+++ b/Source/Machine.Specifications.Mvc.Specs/ViewResultBaseExtensionsSpecs.cs
@@ -22,7 +22,7 @@ namespace Machine.Specifications.Mvc.Specs
 
         It should_not_throw_an_exception = () => exception.ShouldBeNull();
 
-        It should_allow_the_chaining_of_view_result_assertions = () => result.ShouldBeOfType<ActionResultAnd<TestViewResult>>();
+        It should_allow_the_chaining_of_view_result_assertions = () => result.ShouldBeAssignableTo<ActionResultAnd<TestViewResult>>();
     }
 
     [Subject(typeof(ViewResultBaseExtensions))]
@@ -34,7 +34,7 @@ namespace Machine.Specifications.Mvc.Specs
 
         private Because of = () => exception = Catch.Exception(() => result = new TestViewResult() {ViewName = ViewName}.ShouldUseView("Other" + ViewName));
 
-        It should_throw_an_exception = () => exception.ShouldBeOfType<SpecificationException>();
+        It should_throw_an_exception = () => exception.ShouldBeAssignableTo<SpecificationException>();
     }
 
     [Subject(typeof(ViewResultBaseExtensions))]
@@ -44,7 +44,7 @@ namespace Machine.Specifications.Mvc.Specs
 
         Because of = () => exception = Catch.Exception(()=> new TestViewResult() { ViewName = "NonDefault" }.ShouldUseDefaultView());
 
-        It should_throw_an_exception = () => exception.ShouldBeOfType<SpecificationException>();
+        It should_throw_an_exception = () => exception.ShouldBeAssignableTo<SpecificationException>();
     }
 
     [Subject(typeof(ViewResultBaseExtensions))]
@@ -57,7 +57,7 @@ namespace Machine.Specifications.Mvc.Specs
 
         It should_not_throw_an_exception = () => exception.ShouldBeNull();
 
-        It should_allow_the_chaining_of_view_result_assertions = () => result.ShouldBeOfType<ActionResultAnd<TestViewResult>>();
+        It should_allow_the_chaining_of_view_result_assertions = () => result.ShouldBeAssignableTo<ActionResultAnd<TestViewResult>>();
     }
 
     [Subject(typeof(ViewResultBaseExtensions))]
@@ -76,7 +76,7 @@ namespace Machine.Specifications.Mvc.Specs
 
         It should_not_throw_an_exception = () => exception.ShouldBeNull();
 
-        It should_should_allow_the_chaining_of_model_type_assertions = () => result.ShouldBeOfType<ModelTypeAnd<string>>();
+        It should_should_allow_the_chaining_of_model_type_assertions = () => result.ShouldBeAssignableTo<ModelTypeAnd<string>>();
     }
 
     [Subject(typeof (ViewResultBaseExtensions))]
@@ -92,7 +92,7 @@ namespace Machine.Specifications.Mvc.Specs
 
         Because of = () => exception = Catch.Exception(() => viewResult.ShouldNotHaveAModel());
 
-        It should_throw_an_exception = () => exception.ShouldBeOfType<SpecificationException>();
+        It should_throw_an_exception = () => exception.ShouldBeAssignableTo<SpecificationException>();
     }
 
     [Subject(typeof(ViewResultBaseExtensions))]
@@ -111,6 +111,6 @@ namespace Machine.Specifications.Mvc.Specs
 
         It should_not_throw_an_exception = () => exception.ShouldBeNull();
 
-        It should_allow_the_chaining_of_view_result_assertions = () => result.ShouldBeOfType<ActionResultAnd<TestViewResult>>();
+        It should_allow_the_chaining_of_view_result_assertions = () => result.ShouldBeAssignableTo<ActionResultAnd<TestViewResult>>();
     }
 }   

--- a/Source/Machine.Specifications.Mvc.Specs/packages.config
+++ b/Source/Machine.Specifications.Mvc.Specs/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Machine.Specifications" version="0.6.2" targetFramework="net45" />
+  <package id="Machine.Specifications" version="0.9.3" targetFramework="net45" />
+  <package id="Machine.Specifications.Should" version="0.9.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.0.0" targetFramework="net45" />
 </packages>

--- a/Source/Machine.Specifications.Mvc/ActionResultExtensions.cs
+++ b/Source/Machine.Specifications.Mvc/ActionResultExtensions.cs
@@ -46,7 +46,7 @@ namespace Machine.Specifications.Mvc
         public static ActionResultAnd<TActionResult> ShouldBeA<TActionResult>(this ActionResult actionResult)
             where TActionResult : ActionResult
         {
-            actionResult.ShouldBeOfType<TActionResult>();
+            actionResult.ShouldBeAssignableTo<TActionResult>();
             return new ActionResultAnd<TActionResult>(actionResult as TActionResult);
         }
     }

--- a/Source/Machine.Specifications.Mvc/ExpressionActionExtensions.cs
+++ b/Source/Machine.Specifications.Mvc/ExpressionActionExtensions.cs
@@ -9,7 +9,7 @@ namespace Machine.Specifications.Mvc
         public static string GetMethodBodyName<TController>(this Expression<Action<TController>> action) where TController : Controller
         {
             action.ShouldNotBeNull();
-            action.Body.ShouldBeOfType<MethodCallExpression>();
+            action.Body.ShouldBeAssignableTo<MethodCallExpression>();
             return ((MethodCallExpression)action.Body).Method.Name;
         }
     }

--- a/Source/Machine.Specifications.Mvc/Machine.Specifications.Mvc.csproj
+++ b/Source/Machine.Specifications.Mvc/Machine.Specifications.Mvc.csproj
@@ -55,16 +55,17 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Machine.Specifications, Version=0.6.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Machine.Specifications.0.6.1\lib\net45\Machine.Specifications.dll</HintPath>
+    <Reference Include="Machine.Specifications, Version=0.9.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Machine.Specifications.0.9.3\lib\net45\Machine.Specifications.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Machine.Specifications.Clr4, Version=0.6.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Machine.Specifications.0.6.1\lib\net45\Machine.Specifications.Clr4.dll</HintPath>
+    <Reference Include="Machine.Specifications.Clr4, Version=0.9.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Machine.Specifications.0.9.3\lib\net45\Machine.Specifications.Clr4.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Machine.Specifications.Should">
-      <HintPath>..\..\packages\Machine.Specifications.0.6.1\lib\net45\Machine.Specifications.Should.dll</HintPath>
+    <Reference Include="Machine.Specifications.Should, Version=0.9.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Machine.Specifications.Should.0.9.0\lib\net45\Machine.Specifications.Should.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Machine.Specifications.TDNetRunner">
       <HintPath>..\..\packages\Machine.Specifications.0.5.10\lib\net40\Machine.Specifications.TDNetRunner.dll</HintPath>

--- a/Source/Machine.Specifications.Mvc/ViewResultBaseExtensions.cs
+++ b/Source/Machine.Specifications.Mvc/ViewResultBaseExtensions.cs
@@ -20,7 +20,7 @@ namespace Machine.Specifications.Mvc
 
         public static ModelTypeAnd<T> ShouldHaveModelOfType<T>(this ViewResultBase viewResult)
         {
-            viewResult.ViewData.Model.ShouldBeOfType<T>();
+            viewResult.ViewData.Model.ShouldBeAssignableTo<T>();
             return new ModelTypeAnd<T>((T) viewResult.ViewData.Model);
         }
 

--- a/Source/Machine.Specifications.Mvc/packages.config
+++ b/Source/Machine.Specifications.Mvc/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Machine.Specifications" version="0.6.2" targetFramework="net45" />
+  <package id="Machine.Specifications" version="0.9.3" targetFramework="net45" />
+  <package id="Machine.Specifications.Should" version="0.9.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I've updated to a new Machine.Specifications version (0.9.3), this is necessary as the newest version does not contain a .ShouldBeOfType<T>() assertion method anymore, and is therefore no longer binary-compatible with your Machine.Specifications.Mvc build.

Please merge the PR and update the corresponding NuGet package so that we can finally update Machine.Specifications at our place.

Thanks in advance & best regards,
D.R.
